### PR TITLE
test: fix the missing super call in constructor

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -48,6 +48,7 @@ function Test(name_, opts_, cb_) {
 
   var args = getTestArgs(name_, opts_, cb_);
 
+  EventEmitter.call(this);
   this.readable = true;
   this.name = args.name || '(anonymous)';
   this.assertCount = 0;


### PR DESCRIPTION
This fixes the following error when using with ShadowNode v0.10.6 within `newListener` feature:

```
TypeError: Cannot read property 'newListener' of undefined
    at bound (/usr/lib/node_modules/tape/lib/test.js:77:16)
    at anonymous (/usr/lib/node_modules/tape/index.js)
    at anonymous (/usr/lib/node_modules/tape/index.js)
    at anonymous (/usr/lib/node_modules/tape/index.js:23:18)
    at anonymous (/data/workspace/test/@yoda/input/initcheck.test.js)
    at anonymous (/usr/lib/node_modules/tape/bin/tape.js:36:17)
```

/cc @legendecas 